### PR TITLE
Simplify transaction logic

### DIFF
--- a/app/routing/handler.go
+++ b/app/routing/handler.go
@@ -19,6 +19,11 @@ func CreateUserHandler(service service.Service) http.HandlerFunc {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
+		validate := validator.New()
+		if err := validate.Struct(req); err != nil {
+			WriteError(r, w, errors.Wrap(types.ErrMalformedRequest, err.Error()))
+			return
+		}
 		resp, err := service.CreateUser(r.Context(), req)
 		if err != nil {
 			WriteError(r, w, err)
@@ -62,6 +67,11 @@ func CreateUserLoanHandler(service service.Service) http.HandlerFunc {
 			return
 		}
 		req.UserID = userID
+		validate := validator.New()
+		if err := validate.Struct(req); err != nil {
+			WriteError(r, w, errors.Wrap(types.ErrMalformedRequest, err.Error()))
+			return
+		}
 		resp, err := service.CreateUserLoan(r.Context(), req)
 		if err != nil {
 			WriteError(r, w, err)

--- a/app/routing/handler.go
+++ b/app/routing/handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func CreateUserHandler() http.HandlerFunc {
+func CreateUserHandler(service service.Service) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ahttp.CreateUserRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -28,7 +28,7 @@ func CreateUserHandler() http.HandlerFunc {
 	})
 }
 
-func GetUserLoansHandler() http.HandlerFunc {
+func GetUserLoansHandler(service service.Service) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userID := chi.URLParam(r, "userID")
 		resp, err := service.GetUserLoans(r.Context(), userID)
@@ -40,7 +40,7 @@ func GetUserLoansHandler() http.HandlerFunc {
 	})
 }
 
-func GetUserLoanByIDHandler() http.HandlerFunc {
+func GetUserLoanByIDHandler(service service.Service) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userID := chi.URLParam(r, "userID")
 		loanID := chi.URLParam(r, "loanID")
@@ -53,7 +53,7 @@ func GetUserLoanByIDHandler() http.HandlerFunc {
 	})
 }
 
-func CreateUserLoanHandler() http.HandlerFunc {
+func CreateUserLoanHandler(service service.Service) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ahttp.CreateLoanRequest
 		userID := chi.URLParam(r, "userID")
@@ -71,7 +71,7 @@ func CreateUserLoanHandler() http.HandlerFunc {
 	})
 }
 
-func UpdateUserLoanByIDHandler() http.HandlerFunc {
+func UpdateUserLoanByIDHandler(service service.Service) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Context().Value(ContextUserIDKey) != "aspire" {
 			WriteError(r, w, errors.Wrap(types.ErrForbidden, "only admin can approve a loan"))
@@ -100,7 +100,7 @@ func UpdateUserLoanByIDHandler() http.HandlerFunc {
 	})
 }
 
-func CreateUserLoanRepaymentHandler() http.HandlerFunc {
+func CreateUserLoanRepaymentHandler(service service.Service) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ahttp.CreateUserLoanRepaymentRequest
 		userID := chi.URLParam(r, "userID")

--- a/app/routing/middleware.go
+++ b/app/routing/middleware.go
@@ -16,7 +16,7 @@ type ContextKey string
 
 const ContextUserIDKey ContextKey = "user_id"
 
-func AuthMiddleware() func(handler http.Handler) http.Handler {
+func AuthMiddleware(repo mysql.Repo) func(handler http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			user, password, ok := r.BasicAuth()
@@ -24,7 +24,7 @@ func AuthMiddleware() func(handler http.Handler) http.Handler {
 				WriteError(r, w, errors.Wrap(types.ErrUnauthorized, "credentials not found in request header"))
 				return
 			}
-			userFromDB, err := mysql.GetUserByID(r.Context(), user)
+			userFromDB, err := repo.GetUserByID(r.Context(), user)
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
 					WriteError(r, w, errors.Wrap(types.ErrUnauthorized, "user not found"))

--- a/app/routing/middleware.go
+++ b/app/routing/middleware.go
@@ -48,7 +48,7 @@ func ValidationUserIdMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		userIDPath := chi.URLParam(r, "userID")
 		userIDAuth := r.Context().Value(ContextUserIDKey)
 		if userIDPath != userIDAuth {
-			errors.Wrap(types.ErrUnauthorized, "cannot access resources of a different user")
+			WriteError(r, w, errors.Wrap(types.ErrUnauthorized, "cannot access resources of a different user"))
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/app/routing/router.go
+++ b/app/routing/router.go
@@ -5,21 +5,22 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/mayankpahwa/aspire-loan-app/app/config"
+	"github.com/mayankpahwa/aspire-loan-app/internal/service"
 )
 
 // Handler initializes handler for the app
-func Handler(conf config.Config) (http.Handler, error) {
+func Handler(conf config.Config, s service.Service) (http.Handler, error) {
 	r := chi.NewRouter()
 	r.Route("/users", func(r chi.Router) {
-		r.Post("/", CreateUserHandler())
+		r.Post("/", CreateUserHandler(s))
 	})
 	r.Route("/users/{userID}/loans", func(r chi.Router) {
-		r.Use(AuthMiddleware())
-		r.Get("/", ValidationUserIdMiddleware(GetUserLoansHandler()))
-		r.Post("/", ValidationUserIdMiddleware(CreateUserLoanHandler()))
-		r.Get("/{loanID}", ValidationUserIdMiddleware(GetUserLoanByIDHandler()))
-		r.Put("/{loanID}", UpdateUserLoanByIDHandler())
-		r.Post("/{loanID}/payments", (CreateUserLoanRepaymentHandler()))
+		r.Use(AuthMiddleware(s.Repo))
+		r.Get("/", ValidationUserIdMiddleware(GetUserLoansHandler(s)))
+		r.Post("/", ValidationUserIdMiddleware(CreateUserLoanHandler(s)))
+		r.Get("/{loanID}", ValidationUserIdMiddleware(GetUserLoanByIDHandler(s)))
+		r.Put("/{loanID}", UpdateUserLoanByIDHandler(s))
+		r.Post("/{loanID}/payments", (CreateUserLoanRepaymentHandler(s)))
 	})
 	return r, nil
 }

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mayankpahwa/aspire-loan-app/app/config"
 	"github.com/mayankpahwa/aspire-loan-app/app/routing"
 	"github.com/mayankpahwa/aspire-loan-app/internal/repo/mysql"
+	"github.com/mayankpahwa/aspire-loan-app/internal/service"
 	"github.com/pkg/errors"
 )
 
@@ -34,7 +35,12 @@ func New() (*Server, error) {
 	if err := mysql.LoadSQLFile(conf.MigrationPath); err != nil {
 		return nil, errors.Wrap(err, "error running migrations")
 	}
-	handler, err := routing.Handler(conf)
+
+	repo := mysql.NewRepo(
+		mysql.GetConnection(),
+	)
+	service := service.NewService(repo)
+	handler, err := routing.Handler(conf, service)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not init handler")
 	}

--- a/internal/repo/mysql/payments.go
+++ b/internal/repo/mysql/payments.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (r Repo) InsertRepayment(ctx context.Context, repayments models.Repayment) error {
-	insertPaymentQuery := "INSERT INTO `repayments` (`id`, `scheduled_repayments_id`, `amount`) VALUES (?, ?, ?)"
+	insertPaymentQuery := "INSERT INTO `repayments` (`id`, `scheduled_repayment_id`, `amount`) VALUES (?, ?, ?)"
 
 	result, err := r.GetExecutor(ctx).ExecContext(ctx, insertPaymentQuery, repayments.ID, repayments.ScheduledRepaymentID, repayments.Amount)
 	if err != nil {

--- a/internal/repo/mysql/payments.go
+++ b/internal/repo/mysql/payments.go
@@ -2,16 +2,15 @@ package mysql
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/mayankpahwa/aspire-loan-app/internal/resources/models"
 )
 
-func InsertRepayment(ctx context.Context, tx *sql.Tx, repayments models.Repayment) error {
+func (r Repo) InsertRepayment(ctx context.Context, repayments models.Repayment) error {
 	insertPaymentQuery := "INSERT INTO `repayments` (`id`, `scheduled_repayments_id`, `amount`) VALUES (?, ?, ?)"
 
-	result, err := tx.ExecContext(ctx, insertPaymentQuery, repayments.ID, repayments.ScheduledRepaymentID, repayments.Amount)
+	result, err := r.GetExecutor(ctx).ExecContext(ctx, insertPaymentQuery, repayments.ID, repayments.ScheduledRepaymentID, repayments.Amount)
 	if err != nil {
 		return err
 	}

--- a/internal/repo/mysql/repo.go
+++ b/internal/repo/mysql/repo.go
@@ -1,0 +1,106 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+type ctxKey string
+
+// CtxTxKey is key for context transaction.
+const CtxTxKey ctxKey = "tx"
+
+type Repo struct {
+	conn *sql.DB
+}
+
+type Executor interface {
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
+type Connection struct {
+	Executor
+}
+
+func NewRepo(db *sql.DB) Repo {
+	return Repo{
+		conn: db,
+	}
+}
+
+func (r Repo) RunInTransaction(ctx context.Context, f func(ctx context.Context) error) error {
+	ctx, err := BeginTransaction(ctx, r.conn, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	if err := f(ctx); err != nil {
+		if errRollback := RollbackTransaction(ctx); errRollback != nil {
+			return fmt.Errorf("failed to rollback, rollback error %s: %w", errRollback.Error(), err)
+		}
+		return err
+	}
+
+	if err := CommitTransaction(ctx); err != nil {
+		if errRollback := RollbackTransaction(ctx); errRollback != nil {
+			return fmt.Errorf("failed to rollback after commit, rollback error %s: %w", errRollback.Error(), err)
+		}
+		return fmt.Errorf("hfpg failed to commit: %w", err)
+	}
+	return nil
+}
+
+// BeginTransaction from the context.
+func BeginTransaction(ctx context.Context, db *sql.DB, opts *sql.TxOptions) (context.Context, error) {
+	if _, err := GetTransaction(ctx); err == nil {
+		return ctx, errors.New("transaction already started")
+	}
+
+	tx, err := db.BeginTx(ctx, opts)
+	if err != nil {
+		return ctx, err
+	}
+
+	return context.WithValue(ctx, CtxTxKey, tx), nil
+}
+
+// GetTransaction will get transaction from context.
+func GetTransaction(ctx context.Context) (*sql.Tx, error) {
+	tx, ok := ctx.Value(CtxTxKey).(*sql.Tx)
+	if !ok {
+		return nil, errors.New("no transaction found in context")
+	}
+
+	return tx, nil
+}
+
+// RollbackTransaction from the context.
+func RollbackTransaction(ctx context.Context) error {
+	tx, err := GetTransaction(ctx)
+	if err != nil {
+		return err
+	}
+
+	return tx.Rollback()
+}
+
+// CommitTransaction from the context.
+func CommitTransaction(ctx context.Context) error {
+	tx, err := GetTransaction(ctx)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (r Repo) GetExecutor(ctx context.Context) Executor {
+	if tx, err := GetTransaction(ctx); err == nil {
+		return Connection{Executor: tx}
+	}
+	return Connection{Executor: r.conn}
+}

--- a/internal/repo/mysql/users.go
+++ b/internal/repo/mysql/users.go
@@ -8,9 +8,9 @@ import (
 )
 
 // GetUserByID fetches a user by ID
-func GetUserByID(ctx context.Context, userID string) (models.User, error) {
+func (r Repo) GetUserByID(ctx context.Context, userID string) (models.User, error) {
 	var user models.User
-	err := GetConnection().
+	err := r.GetExecutor(ctx).
 		QueryRowContext(ctx, "SELECT id, password FROM users WHERE id = ?", userID).
 		Scan(&user.ID, &user.Password)
 	if err != nil {
@@ -20,8 +20,8 @@ func GetUserByID(ctx context.Context, userID string) (models.User, error) {
 }
 
 // CreateUser inserts an entry into the `users` table
-func CreateUser(ctx context.Context, user models.User) error {
-	result, err := GetConnection().
+func (r Repo) CreateUser(ctx context.Context, user models.User) error {
+	result, err := r.GetExecutor(ctx).
 		ExecContext(ctx, "INSERT INTO `users` (`id`, `password`) VALUES (?, ?)", user.ID, user.Password)
 	if err != nil {
 		return err

--- a/internal/resources/http/loans.go
+++ b/internal/resources/http/loans.go
@@ -2,8 +2,8 @@ package ahttp
 
 type CreateLoanRequest struct {
 	UserID string `json:"-"`
-	Amount int    `json:"amount"`
-	Term   int    `json:"term"`
+	Amount int    `json:"amount" validate:"required,gt=0"`
+	Term   int    `json:"term" validate:"required,gt=0"`
 }
 
 type CreateLoanResponse struct {

--- a/internal/service/response.go
+++ b/internal/service/response.go
@@ -22,13 +22,25 @@ func createGetUserLoansResponse(response []models.UserLoan) ahttp.GetUserLoansRe
 	return resp
 }
 
-func createGetUserLoanByIDResponse(response models.UserLoan) ahttp.SingleUserLoanResponse {
+func createGetUserLoanByIDResponse(response models.UserLoan, scheduledRepayments []models.ScheduledRepayment) ahttp.SingleUserLoanResponse {
+	scheduledRepaymentsResp := make([]ahttp.SingleScheduledRepayment, 0)
+	for _, scheduledRepayment := range scheduledRepayments {
+		singleScheduledRepayment := ahttp.SingleScheduledRepayment{
+			ID:     scheduledRepayment.ID.String(),
+			LoanID: scheduledRepayment.LoanID.String(),
+			Amount: scheduledRepayment.Amount,
+			Date:   scheduledRepayment.Date,
+			Status: scheduledRepayment.Status,
+		}
+		scheduledRepaymentsResp = append(scheduledRepaymentsResp, singleScheduledRepayment)
+	}
 	return ahttp.SingleUserLoanResponse{
-		ID:          response.ID.String(),
-		Amount:      response.Amount,
-		Term:        response.Term,
-		DateCreated: response.DateCreated,
-		Status:      response.Status,
+		ID:                  response.ID.String(),
+		Amount:              response.Amount,
+		Term:                response.Term,
+		DateCreated:         response.DateCreated,
+		Status:              response.Status,
+		ScheduledRepayments: scheduledRepaymentsResp,
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -14,8 +14,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-func CreateUser(ctx context.Context, req ahttp.CreateUserRequest) (ahttp.CreateUserResponse, error) {
-	_, err := mysql.GetUserByID(ctx, req.ID)
+type Service struct {
+	Repo mysql.Repo
+}
+
+func NewService(repo mysql.Repo) Service {
+	return Service{
+		Repo: repo,
+	}
+}
+
+func (s Service) CreateUser(ctx context.Context, req ahttp.CreateUserRequest) (ahttp.CreateUserResponse, error) {
+	_, err := s.Repo.GetUserByID(ctx, req.ID)
 	if err == nil {
 		return ahttp.CreateUserResponse{}, errors.Wrap(types.ErrUnprocessableEntity, "user already exists")
 	}
@@ -26,35 +36,32 @@ func CreateUser(ctx context.Context, req ahttp.CreateUserRequest) (ahttp.CreateU
 		ID:       req.ID,
 		Password: req.Password,
 	}
-	if err := mysql.CreateUser(ctx, userToInsert); err != nil {
+	if err := s.Repo.CreateUser(ctx, userToInsert); err != nil {
 		return ahttp.CreateUserResponse{}, err
 	}
 	return ahttp.CreateUserResponse{ID: req.ID}, nil
 }
 
 // CreateUserLoan inserts a user loan and its scheduled payments
-func CreateUserLoan(ctx context.Context, req ahttp.CreateLoanRequest) (ahttp.SingleUserLoanResponse, error) {
+func (s Service) CreateUserLoan(ctx context.Context, req ahttp.CreateLoanRequest) (ahttp.SingleUserLoanResponse, error) {
+	var scheduledRepayments []models.ScheduledRepayment
 	loanToInsert := getLoanToInsert(req)
-	tx, err := mysql.GetConnection().BeginTx(ctx, nil)
+	err := s.Repo.RunInTransaction(ctx, func(ctx context.Context) error {
+		if err := s.Repo.InsertUserLoan(ctx, loanToInsert); err != nil {
+			return err
+		}
+		scheduledRepayments = getScheduledRepayments(loanToInsert)
+		return s.Repo.InsertScheduledRepayments(ctx, scheduledRepayments)
+	})
 	if err != nil {
-		return ahttp.SingleUserLoanResponse{}, err
+		return ahttp.SingleUserLoanResponse{}, nil
 	}
-	if err := mysql.InsertUserLoan(ctx, tx, loanToInsert); err != nil {
-		tx.Rollback()
-		return ahttp.SingleUserLoanResponse{}, err
-	}
-	scheduledRepayments := getScheduledRepayments(loanToInsert)
-	if err := mysql.InsertScheduledRepayments(ctx, tx, scheduledRepayments); err != nil {
-		tx.Rollback()
-		return ahttp.SingleUserLoanResponse{}, err
-	}
-	tx.Commit()
 	return createInsertUserLoanResponse(loanToInsert, scheduledRepayments), nil
 }
 
 // GetUserLoans fetches all loans for a user
-func GetUserLoans(ctx context.Context, userID string) (ahttp.GetUserLoansResponse, error) {
-	result, err := mysql.GetUserLoans(ctx, userID)
+func (s Service) GetUserLoans(ctx context.Context, userID string) (ahttp.GetUserLoansResponse, error) {
+	result, err := s.Repo.GetUserLoans(ctx, userID)
 	if err != nil {
 		return ahttp.GetUserLoansResponse{}, errors.Wrap(err, "failed fetching user loans")
 	}
@@ -62,8 +69,8 @@ func GetUserLoans(ctx context.Context, userID string) (ahttp.GetUserLoansRespons
 }
 
 // GetUserLoanByID fetches a user loan by loanID
-func GetUserLoanByID(ctx context.Context, userID, loanID string) (ahttp.SingleUserLoanResponse, error) {
-	result, err := mysql.GetUserLoanByID(ctx, userID, loanID)
+func (s Service) GetUserLoanByID(ctx context.Context, userID, loanID string) (ahttp.SingleUserLoanResponse, error) {
+	result, err := s.Repo.GetUserLoanByID(ctx, userID, loanID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ahttp.SingleUserLoanResponse{}, errors.Wrap(types.ErrNoResourceFound, "loan not found")
@@ -74,8 +81,8 @@ func GetUserLoanByID(ctx context.Context, userID, loanID string) (ahttp.SingleUs
 }
 
 // UpdateUserLoanStatus updates a loan status
-func UpdateUserLoanStatus(ctx context.Context, req ahttp.UpdateUserLoanRequest) (ahttp.UpdateUserLoanResponse, error) {
-	result, err := mysql.GetUserLoanByID(ctx, req.UserID, req.LoanID)
+func (s Service) UpdateUserLoanStatus(ctx context.Context, req ahttp.UpdateUserLoanRequest) (ahttp.UpdateUserLoanResponse, error) {
+	result, err := s.Repo.GetUserLoanByID(ctx, req.UserID, req.LoanID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ahttp.UpdateUserLoanResponse{}, errors.Wrap(types.ErrNoResourceFound, "loan not found")
@@ -88,15 +95,15 @@ func UpdateUserLoanStatus(ctx context.Context, req ahttp.UpdateUserLoanRequest) 
 	if result.Status == types.LoanStatusApproved.ToString() {
 		return ahttp.UpdateUserLoanResponse{Status: req.Status}, nil
 	}
-	if err := mysql.UpdateUserLoanStatus(ctx, nil, req.LoanID, types.LoanStatusApproved.ToString()); err != nil {
+	if err := s.Repo.UpdateUserLoanStatus(ctx, req.LoanID, types.LoanStatusApproved.ToString()); err != nil {
 		return ahttp.UpdateUserLoanResponse{}, err
 	}
 	return ahttp.UpdateUserLoanResponse{Status: req.Status}, nil
 }
 
 // CreateUserLoanRepayment inserts a loan repayment and updates the scheduled repayment status and loan status
-func CreateUserLoanRepayment(ctx context.Context, req ahttp.CreateUserLoanRepaymentRequest) error {
-	loanFromDB, err := mysql.GetUserLoanByID(ctx, req.UserID, req.LoanID)
+func (s Service) CreateUserLoanRepayment(ctx context.Context, req ahttp.CreateUserLoanRepaymentRequest) error {
+	loanFromDB, err := s.Repo.GetUserLoanByID(ctx, req.UserID, req.LoanID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return errors.Wrap(types.ErrNoResourceFound, "loan not found")
@@ -106,7 +113,7 @@ func CreateUserLoanRepayment(ctx context.Context, req ahttp.CreateUserLoanRepaym
 	if loanFromDB.Status != types.LoanStatusApproved.ToString() {
 		return errors.Wrap(types.ErrUnprocessableEntity, fmt.Sprintf("Loan not in APPROVED status"))
 	}
-	scheduledRepaymentFromDB, err := mysql.GetScheduledRepaymentsByID(ctx, req.ScheduledRepaymentID)
+	scheduledRepaymentFromDB, err := s.Repo.GetScheduledRepaymentsByID(ctx, req.ScheduledRepaymentID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return errors.Wrap(types.ErrNoResourceFound, "scheduled payment not found")
@@ -122,35 +129,28 @@ func CreateUserLoanRepayment(ctx context.Context, req ahttp.CreateUserLoanRepaym
 		return errors.Wrap(types.ErrUnprocessableEntity, fmt.Sprintf("Repayment amount should be more than scheduled repayment amount"))
 	}
 
-	tx, err := mysql.GetConnection().BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	repayment := getRepayment(req)
-	if err := mysql.InsertRepayment(ctx, tx, repayment); err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	if err := mysql.UpdateScheduledRepaymentStatus(ctx, tx, req.ScheduledRepaymentID, types.ScheduledRepaymentStatusPaid.ToString()); err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	scheduledRepayments, err := mysql.GetScheduledRepaymentsByLoanID(ctx, tx, req.LoanID)
-	if err != nil {
-		tx.Rollback()
-		return err
-	}
-	if shouldChangeLoanStatus(scheduledRepayments) {
-		if err := mysql.UpdateUserLoanStatus(ctx, tx, req.LoanID, types.LoanStatusPaid.ToString()); err != nil {
-			tx.Rollback()
+	txErr := s.Repo.RunInTransaction(ctx, func(ctx context.Context) error {
+		repayment := getRepayment(req)
+		if err := s.Repo.InsertRepayment(ctx, repayment); err != nil {
 			return err
 		}
-	}
 
-	tx.Commit()
-	return nil
+		if err := s.Repo.UpdateScheduledRepaymentStatus(ctx, req.ScheduledRepaymentID, types.ScheduledRepaymentStatusPaid.ToString()); err != nil {
+			return err
+		}
+
+		scheduledRepayments, err := s.Repo.GetScheduledRepaymentsByLoanID(ctx, req.LoanID)
+		if err != nil {
+			return err
+		}
+		if shouldChangeLoanStatus(scheduledRepayments) {
+			if err := s.Repo.UpdateUserLoanStatus(ctx, req.LoanID, types.LoanStatusPaid.ToString()); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return txErr
 }
 
 func getLoanToInsert(requestLoan ahttp.CreateLoanRequest) models.UserLoan {

--- a/migrations/db_setup.sql
+++ b/migrations/db_setup.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS users (id varchar(255)  NOT NULL, password varchar(255) NOT NULL, date_created DATETIME DEFAULT CURRENT_TIMESTAMP(), PRIMARY KEY (`id`));
-CREATE TABLE IF NOT EXISTS loans (id VARCHAR(40), user_id varchar(250), amount int, term int, date_created DATE, status enum ('PENDING', 'APPROVED'), PRIMARY KEY  (`id`), FOREIGN KEY (`user_id`) REFERENCES users(id));
-CREATE TABLE IF NOT EXISTS scheduled_repayments (id VARCHAR(40), loan_id VARCHAR(40), amount decimal(9,4), date DATE, status enum ('PENDING', 'PAID'), PRIMARY KEY  (`id`), FOREIGN KEY (`loan_id`) REFERENCES loans(id));
-CREATE TABLE IF NOT EXISTS repayments (id VARCHAR(40), scheduled_repayment_id VARCHAR(40), amount decimal(9,4), date_created DATETIME DEFAULT CURRENT_TIMESTAMP(), PRIMARY KEY  (`id`), FOREIGN KEY (`scheduled_repayment_id`) REFERENCES scheduled_repayments(id));
+CREATE TABLE IF NOT EXISTS loans (id VARCHAR(40), user_id varchar(250), amount int, term int, date_created DATE, status enum ('PENDING', 'APPROVED', 'PAID'), PRIMARY KEY  (`id`), FOREIGN KEY (`user_id`) REFERENCES users(id));
+CREATE TABLE IF NOT EXISTS scheduled_repayments (id VARCHAR(40), loan_id VARCHAR(40), amount decimal(9,2), date DATE, status enum ('PENDING', 'PAID'), PRIMARY KEY  (`id`), FOREIGN KEY (`loan_id`) REFERENCES loans(id));
+CREATE TABLE IF NOT EXISTS repayments (id VARCHAR(40), scheduled_repayment_id VARCHAR(40), amount decimal(9,2), date_created DATETIME DEFAULT CURRENT_TIMESTAMP(), PRIMARY KEY  (`id`), FOREIGN KEY (`scheduled_repayment_id`) REFERENCES scheduled_repayments(id));
 INSERT IGNORE INTO users(id, password) VALUES ('aspire', 'aspire');


### PR DESCRIPTION
This PR
- Adds `Executor` logic on top of `sql.DB`'s transactions to simplify the transaction code
- Fixes minor issues and bugs